### PR TITLE
cas particuliers regles pour uber pas dispo

### DIFF
--- a/app/services/ride_conversation.rb
+++ b/app/services/ride_conversation.rb
@@ -18,19 +18,32 @@ class RideConversation
 
     if @ride.start_address = @start_address
       @ride.save
-      @time = UberService.new(@ride).time_estimates / 60
+      @time = UberService.new(@ride).time_estimates / 60 if @time.class == Integer
     end
 
     if @start_address && @end_address
       @price = UberService.new(@ride).price_estimates
-      @answer = "Le prix de la course de #{@start_address_nice } " \
+      if @price == "distance_exceeded"
+        @answer = "Désolé, La distance entre #{@start_address_nice } " \
+                "à #{@end_address_nice} est supérieure à 100 kilomètres. Veuillez réessayer !"
+      elsif @price == "no_uber"
+        @answer = "Désolé, nous ne trouvons pas de Uber entre #{@start_address_nice } " \
+                "et #{@end_address_nice}. Veuillez réessayer !"
+      else
+        @answer = "Le prix de la course de #{@start_address_nice } " \
                 "à #{@end_address_nice} est de #{@price} (une voiture peut être là " \
                 "dans #{@time} minutes). Envoyez OUI pour commander"
+      end
+
     elsif @start_address
-      @answer = "Une voiture peut venir vous chercher au #{@start_address_nice} " \
+      if @time.class != Integer
+        @answer = "Désolé, la zone autour de #{@start_address_nice} n'est pas encore couverte !"
+      else
+        @answer = "Une voiture peut venir vous chercher au #{@start_address_nice} " \
                 "dans #{@time} minutes. Pourriez-vous me renvoyer votre adresse " \
                 "d'arrivée pour que je puisse vous proposer un prix ? Envoyer ANNULER " \
                 "si j'ai mal compris."
+      end
     elsif @end_address
       @answer = "Je n'ai pas compris votre adresse de départ. Pourriez-vous " \
                 "me la renvoyer ? "

--- a/app/services/uber_service.rb
+++ b/app/services/uber_service.rb
@@ -27,7 +27,11 @@ class UberService
         end_longitude: @ride.end_address.longitude
         )
       car = estimation.detect {|e| e.display_name == "uberX"}
-      car[:estimate]
+      if car
+        car[:estimate]
+      else
+        return "no_uber"
+      end
     rescue Uber::Error::UnprocessableEntity => error
       error.message
     end
@@ -35,9 +39,9 @@ class UberService
 
   def time_estimates
     car = @client.time_estimations(
-      start_latitude: @ride.start_address.latitude,
-      start_longitude: @ride.start_address.longitude
-      ).detect {|e| e.display_name == "uberX"}
+    start_latitude: @ride.start_address.latitude,
+    start_longitude: @ride.start_address.longitude
+    ).detect {|e| e.display_name == "uberX"}
     car[:estimate]
   end
 end


### PR DESCRIPTION
Correction des reponses pour :
- PAs de Uber dispo dans les parages
- Disctance trop grandes entres les 2 spots
